### PR TITLE
Some fixes and config updates ready for finetuning run

### DIFF
--- a/examples/image-classification/convnext_ipuconfig.json
+++ b/examples/image-classification/convnext_ipuconfig.json
@@ -1,13 +1,44 @@
 {
-    "enable_half_first_order_momentum": false,
-    "replication_factor": {"pod4": 1, "pod8": 1, "pod16": 1, "pod32": 1, "pod64": 1, "default": 1},
-    "gradient_accumulation_steps": 128,
-    "device_iterations": 1,
-    "executable_cache_dir": "./exe_cache",
+  "embedding_serialization_factor": 1,
+  "recompute_checkpoint_every_layer": true,
+  "optimizer_state_offchip": true,
+  "replicated_tensor_sharding": true,
+  "enable_half_first_order_momentum": false,
+  "enable_half_partials": false,
+  "fp32": true,
 
-    "inference_device_iterations": 4,
-    "inference_replication_factor": {"pod4": 1, "pod8": 2, "pod16": 4, "pod32": 8, "pod64": 16, "default": 1},
+  "per_device_train_batch_size": 1,
+  "per_device_eval_batch_size": 1,
 
-    "ipus_per_replica": 1,
-    "layers_per_ipu": [4]
+  "pod_type": "pod16",
+  "replication_factor": {"pod4": 1, "pod8": 2, "pod16": 16, "pod32": 8, "pod64": 16, "default": 1},
+  "device_iterations": 1,
+  "inference_device_iterations": 1,
+  "inference_replication_factor": 16,
+  "gradient_accumulation_steps": 256,
+  "executable_cache_dir": "./exe_cache",
+
+  "learning_rate": 3e-4,
+  "num_train_epochs": 1,
+  "do_train": true,
+  "do_eval": true,
+  "train_val_split": 0.1,
+  "train_dir": "/localdata/ai-datasets/imagenet-raw-data/train",
+  "validation_dir": "/localdata/ai-datasets/imagenet-raw-data/validation",
+  "output_dir": "./outputs",
+  "model_name_or_path": "facebook/convnext-tiny-224",
+
+  "ipus_per_replica": 1,
+  "layers_per_ipu": [6],
+  "matmul_proportion": [0.1],
+
+  "dataloader_drop_last": true,
+  "dataloader_mode": "async",
+  "dataloader_num_workers": 16,
+
+  "seed": 1337,
+  "overwrite_output_dir": true,
+  "ipu_config_name": "./convnext_ipuconfig.json",
+  "disable_feature_extractor" : true,
+  "disable_mixup": true
   }

--- a/examples/image-classification/requirements.txt
+++ b/examples/image-classification/requirements.txt
@@ -3,3 +3,4 @@ git+https://github.com/huggingface/transformers.git # Requires latest version of
 datasets>=1.15.0
 torchvision==0.11.1+cpu
 scikit-learn==0.24.2
+timm==0.5.4

--- a/examples/image-classification/run_convnex.sh
+++ b/examples/image-classification/run_convnex.sh
@@ -1,6 +1,0 @@
-python run_image_classification_on_local_data.py \
---train_dir /localdata/datasets/imagenet-raw-data/train  \
---train_val_split 0.1  --output_dir ./outputs/ --do_train  --do_eval --num_train_epochs 3 \
---learning_rate 3e-4     --per_device_train_batch_size 2  --per_device_eval_batch_size 1 \
---pod_type pod16     --dataloader_num_workers 8     --dataloader_drop_last  \
---seed 1337 --model_name_or_path facebook/convnext-tiny-224 --fp32 --disable_feature_extractor --disable_mixup

--- a/examples/image-classification/run_convnext.sh
+++ b/examples/image-classification/run_convnext.sh
@@ -1,0 +1,1 @@
+python run_image_classification_on_local_data.py ./convnext_ipuconfig.json

--- a/examples/image-classification/run_image_classification_on_local_data.py
+++ b/examples/image-classification/run_image_classification_on_local_data.py
@@ -303,13 +303,12 @@ def main():
     )
     config.smoothing=training_args.smoothing
 
-    # ipu_config = IPUConfig.from_pretrained(
-    #     training_args.ipu_config_name if training_args.ipu_config_name else model_args.model_name_or_path,
-    #     cache_dir=model_args.cache_dir,
-    #     revision=model_args.model_revision,
-    #     use_auth_token=True if model_args.use_auth_token else None,
-    # )
-    ipu_config = IPUConfig.from_json_file("convnext_ipuconfig.json")
+    ipu_config = IPUConfig.from_pretrained(
+        training_args.ipu_config_name if training_args.ipu_config_name else model_args.model_name_or_path,
+        cache_dir=model_args.cache_dir,
+        revision=model_args.model_revision,
+        use_auth_token=True if model_args.use_auth_token else None,
+    )
     model = AutoModelForImageClassification.from_pretrained(
         model_args.model_name_or_path,
         from_tf=bool(".ckpt" in model_args.model_name_or_path),

--- a/optimum/graphcore/models/convnext/modeling_convnext.py
+++ b/optimum/graphcore/models/convnext/modeling_convnext.py
@@ -2,7 +2,9 @@ import torch
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 import poptorch
 import transformers
-from transformers.models.convnext.modeling_convnext import ConvNextClassifierOutput
+from transformers.modeling_outputs import (
+    ImageClassifierOutputWithNoAttention,
+)
 from optimum.utils import logging
 from ...modeling_utils import PipelineMixin, get_layer_ipu, recomputation_checkpoint, register
 from timm.loss import LabelSmoothingCrossEntropy, SoftTargetCrossEntropy
@@ -79,7 +81,7 @@ class PipelinedConvNextForImageClassification(transformers.ConvNextForImageClass
             output = (logits,) + outputs[2:]
             return ((loss,) + output) if loss is not None else output
 
-        return ConvNextClassifierOutput(
+        return ImageClassifierOutputWithNoAttention(
             loss=loss,
             logits=logits,
             hidden_states=outputs.hidden_states,


### PR DESCRIPTION
# Some fixes and config updates ready for finetuning run

- Updated convnext_ipuconfig with the settings from RT that fit fp32 bs1
- Fixed classifier outputs to match upstream transformers changes
- added timm to requirements file
- uncommented `IPUConfig.from_pretrained` block
- renamed run_convnext.sh and updated to use the config file for all settings

